### PR TITLE
skip Fragment element

### DIFF
--- a/packages/babel-plugin-open-source/babel.js
+++ b/packages/babel-plugin-open-source/babel.js
@@ -36,6 +36,8 @@ module.exports = declare(api => {
 
       state.file.set('hasJSX', true);
 
+      if (path.container.openingElement.name.name === 'Fragment') return
+
       const sourceData = JSON.stringify({
         filename: state.filename,
         start: location.start.line,


### PR DESCRIPTION
Thank you for this library, it really scratches an itch :smile: 

I found using `React.Fragment` with this library cause a warning(`Warning: Invalid prop data-source supplied to React.Fragment. React.Fragment can only have key and children props.`), and this PR is fix for it.