### PR TITLE
Added Editor Protocol option using babel option and env var.

### DIFF
--- a/packages/babel-plugin-open-source/README.md
+++ b/packages/babel-plugin-open-source/README.md
@@ -23,10 +23,24 @@ Add the plugin to your babel config.
 // .babelrc
 {
    "plugins": [
-      "babel-plugin-open-source"
+      "babel-plugin-open-source",
+      "editor:"vscode", // vscode-insiders | sublime | atom
     ]
 }
 ```
+
+Current Supoorted editors are:
+- VSCode
+- VSCode-Insiders
+- Sublime
+- Atom
+- Phpstorm
+
+Personalized editors
+- You can also specify the supported editors in your `.env` with the key `BABEL_OPEN_SOURCE_EDITOR`.
+- `BABEL_OPEN_SOURCE_EDITOR` value would override the `editor` option passed in the plugin.
+
+---
 
  Docs for changing babel config: [Nextjs](https://nextjs.org/docs/advanced-features/customizing-babel-config) | [create react app](https://github.com/timarney/react-app-rewired)
 

--- a/packages/babel-plugin-open-source/README.md
+++ b/packages/babel-plugin-open-source/README.md
@@ -24,21 +24,12 @@ Add the plugin to your babel config.
 {
    "plugins": [
       "babel-plugin-open-source",
-      "editor:"vscode", // vscode-insiders | sublime | atom
+      "editor:"vscode", // optional, default: "vscode". options: vscode | vscode-insiders | sublime | atom | phpstorm
     ]
 }
 ```
 
-Currently Supported editors are:
-- VSCode
-- VSCode-Insiders
-- Sublime
-- Atom
-- Phpstorm
-
-Personalized editors
-- You can also specify the supported editors in your `.env` with the key `BABEL_OPEN_SOURCE_EDITOR`.
-- `BABEL_OPEN_SOURCE_EDITOR` value would override the `editor` option passed in the plugin.
+If folks in your team use different editors, you can customise the editor just for you by adding the key `BABEL_OPEN_SOURCE_EDITOR` in your `.env` file.
 
 ---
 

--- a/packages/babel-plugin-open-source/README.md
+++ b/packages/babel-plugin-open-source/README.md
@@ -29,7 +29,7 @@ Add the plugin to your babel config.
 }
 ```
 
-Current Supoorted editors are:
+Currently Supported editors are:
 - VSCode
 - VSCode-Insiders
 - Sublime

--- a/packages/babel-plugin-open-source/babel.js
+++ b/packages/babel-plugin-open-source/babel.js
@@ -1,5 +1,8 @@
 const { declare } = require('@babel/helper-plugin-utils')
 const { types: t } = require('@babel/core')
+const fs = require('fs');
+const dotenv = require('dotenv')
+const filePath = require('path')
 
 const scriptLocation = 'babel-plugin-open-source/script.js'
 
@@ -30,9 +33,16 @@ module.exports = declare(api => {
       if (process.env.NODE_ENV !== 'development') return
 
       const location = path.container.openingElement.loc
+      let editorURLProtocol = "vscode"
 
       // the element was generated and doesn't have location information
       if (!location) return
+
+      try {
+        if(state.opts.envPath) {
+          editorURLProtocol = dotenv.parse(fs.readFileSync(filePath.resolve(process.cwd(),state.opts.envPath), 'utf8'))?.BABEL_OPEN_SOURCE_EDITOR;
+        }
+      }  catch (error) {}
 
       state.file.set('hasJSX', true);
 
@@ -41,7 +51,8 @@ module.exports = declare(api => {
       const sourceData = JSON.stringify({
         filename: state.filename,
         start: location.start.line,
-        end: location.end.line
+        end: location.end.line,
+        editor: state.opts.editorURLProtocol || editorURLProtocol,
       })
 
       path.container.openingElement.attributes.push(

--- a/packages/babel-plugin-open-source/babel.js
+++ b/packages/babel-plugin-open-source/babel.js
@@ -1,8 +1,6 @@
 const { declare } = require('@babel/helper-plugin-utils')
 const { types: t } = require('@babel/core')
-const fs = require('fs');
 const dotenv = require('dotenv')
-const filePath = require('path')
 
 const scriptLocation = 'babel-plugin-open-source/script.js'
 
@@ -39,17 +37,15 @@ module.exports = declare(api => {
       // the element was generated and doesn't have location information
       if (!location) return
 
-      try {
-        if(state.opts.envPath) {
-          editor = dotenv.parse(fs.readFileSync(filePath.resolve(process.cwd(),state.opts.envPath), 'utf8'))?.BABEL_OPEN_SOURCE_EDITOR;
-        }
-      }  catch (error) {
-        console.error("ERROR in Babel Plugin Open Source", error)
-      }
-
       state.file.set('hasJSX', true);
 
       if (path.container.openingElement.name.name === 'Fragment') return
+
+      // picks root directory's .env file
+      const editorInENV = dotenv.config()?.parsed?.["BABEL_OPEN_SOURCE_EDITOR"];
+      if(editorInENV) {
+        editor = editorInENV;
+      }
 
       if(editor === 'sublime') {
         // https://macromates.com/blog/2007/the-textmate-url-scheme/
@@ -69,10 +65,7 @@ module.exports = declare(api => {
 
 
       const sourceData = JSON.stringify({
-        filename: state.filename,
-        start: location.start.line,
-        end: location.end.line,
-        url: url,
+        url
       })
 
       path.container.openingElement.attributes.push(

--- a/packages/babel-plugin-open-source/package.json
+++ b/packages/babel-plugin-open-source/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/core": ">7.0.0",
-    "@babel/helper-plugin-utils": ">7.0.0"
+    "@babel/helper-plugin-utils": ">7.0.0",
+    "dotenv": "^10.0.0"
   }
 }

--- a/packages/babel-plugin-open-source/script.js
+++ b/packages/babel-plugin-open-source/script.js
@@ -4,7 +4,7 @@ if (typeof document !== 'undefined') {
     if (!event.altKey) return;
 
     event.preventDefault();
-    const { filename, start, url } = JSON.parse(event.target.dataset.source)
+    const { url } = JSON.parse(event.target.dataset.source)
     window.open(url)
   })
 }

--- a/packages/babel-plugin-open-source/script.js
+++ b/packages/babel-plugin-open-source/script.js
@@ -4,7 +4,7 @@ if (typeof document !== 'undefined') {
     if (!event.altKey) return;
 
     event.preventDefault();
-    const { filename, start } = JSON.parse(event.target.dataset.source)
-    window.open('vscode://file/' + filename + ':' + start)
+    const { filename, start, editor } = JSON.parse(event.target.dataset.source)
+    window.open(editor + '://file/' + filename + ':' + start)
   })
 }

--- a/packages/babel-plugin-open-source/script.js
+++ b/packages/babel-plugin-open-source/script.js
@@ -4,7 +4,7 @@ if (typeof document !== 'undefined') {
     if (!event.altKey) return;
 
     event.preventDefault();
-    const { filename, start, editor } = JSON.parse(event.target.dataset.source)
-    window.open(editor + '://file/' + filename + ':' + start)
+    const { filename, start, url } = JSON.parse(event.target.dataset.source)
+    window.open(url)
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -625,6 +625,14 @@ axobject-query@^2.2.0:
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
   integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
 
+babel-plugin-open-source@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-open-source/-/babel-plugin-open-source-1.0.3.tgz#e746efa5757f413b17d5659855bbf84471230c1e"
+  integrity sha512-tFn516TALNhtYJMhE6GCMCWfz7tZubV3iO1zAw+kPOACqbcGN/1Tr+HmAAZcAyvQChe+ZRCA8xeZ29yMzc39EQ==
+  dependencies:
+    "@babel/core" ">7.0.0"
+    "@babel/helper-plugin-utils" ">7.0.0"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -1105,6 +1113,11 @@ domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
   integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
+
+dotenv@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
+  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
 electron-to-chromium@^1.3.723, electron-to-chromium@^1.3.830:
   version "1.3.836"


### PR DESCRIPTION
Hey Sid,
This plugin is super useful.
I have added a feature for letting user enter their preferred editor.
This PR works on the points of #1 and #6.

This can be done via a babel option called "editorURLProtocol" or from an .env var.

Babel option has higher priority than env approach.
Please review the code and let me know if any futher changes are required.

Thanks!