### PR TITLE
Prevent duplicate data-source attribute

### DIFF
--- a/packages/babel-plugin-open-source/babel.js
+++ b/packages/babel-plugin-open-source/babel.js
@@ -62,6 +62,13 @@ module.exports = declare((api) => {
         return;
       }
 
+      // don't add data-source if it already exists
+      const hasDataSource = path.container.openingElement.attributes.find(
+        (attr) => attr.name && attr.name.name === 'data-source'
+      );
+
+      if (hasDataSource) return;
+
       const editor = state.file.get('editor');
 
       if (editor === 'sublime') {


### PR DESCRIPTION
The plugin is encountering issues in vite 4, specifically showing a warning message of "Duplicate 'data-source' attribute in JSX element." To resolve this issue, a change has been implemented to avoid the double inclusion of the data-source attribute.